### PR TITLE
chore(ci): add create-release workflow

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -5,9 +5,8 @@ on:
 
 jobs:
   create-release:
-    uses: MCEngine-Action/gradle/.github/workflows/create-release-extension-with-testing-jar.yml@master
+    uses: MCEngine-Extension/gradle/.github/workflows/create-release-extension-with-testing-jar.yml@master
     with:
       repo-name: ${{ github.repository }}
     secrets:
       USER_GITHUB_TOKEN: ${{ secrets.USER_GITHUB_TOKEN }}
-


### PR DESCRIPTION
This PR adds a GitHub Actions workflow to create releases via `MCEngine-Action/gradle`.

It was created automatically across the org.